### PR TITLE
"upcoming"以外のステータスの場合、cron jobが回るたびに通知がなされてしまう対策

### DIFF
--- a/src/tasks/updateVideoStatuses.js
+++ b/src/tasks/updateVideoStatuses.js
@@ -110,7 +110,7 @@ async function processVideoUpdate(apiVideoInfo, dbVideo) {
   };
 
   // ステータスが `upcoming` 以外の場合の処理
-  if (apiVideoInfo.liveBroadcastContent !== "upcoming") {
+  if (apiVideoInfo.liveBroadcastContent !== "upcoming" && apiVideoInfo.liveBroadcastContent !== updateVideoData.status) {
     console.info(`✅ ステータス変更 - (Video_ID: ${video_id}) 新ステータス: ${apiVideoInfo.liveBroadcastContent}`);
     await updateExistingVideoData(updateVideoData);
 


### PR DESCRIPTION
upcoming以外、特にliveスタータスの場合にvideo statusが取得されるたびにDiscord側へ通知が送信されてしまう問題
→update前にDBから取得したstatusとAPIで取得したstatusを比較することで、重複してスタータスが更新されることを抑制する

=====
最近になって初期バージョンからアップデートしたところ、statusの取得ロジックが変わったせいなのか連投されてしまうバグ的挙動が見られたので応急処置としてのpull requestです。完璧に重複送信は防げていませんが、ほぼほぼ0になります。